### PR TITLE
"player was kicked" -> "player was banned"

### DIFF
--- a/Jaket.csproj
+++ b/Jaket.csproj
@@ -19,16 +19,16 @@
 	  <PackageReference Include="UnityEngine.Modules" Version="2019.4.40" IncludeAssets="compile" />
 
     <Reference Include="BepInEx">                       <HintPath>lib\BepInEx.dll                   </HintPath> </Reference>
-    <Reference Include="Harmony">                       <HintPath>lib\0Harmony.dll                  </HintPath> </Reference>
+    <Reference Include="0Harmony">                      <HintPath>lib\0Harmony.dll                  </HintPath> </Reference>
 
     <Reference Include="Assembly-CSharp">               <HintPath>lib\Assembly-CSharp.dll           </HintPath> </Reference>
     <Reference Include="Facepunch.Steamworks.Win64">    <HintPath>lib\Facepunch.Steamworks.Win64.dll</HintPath> </Reference>
     <Reference Include="plog">                          <HintPath>lib\plog.dll                      </HintPath> </Reference>
 
-    <Reference Include="TMPro">                         <HintPath>lib\Unity.TextMeshPro.dll         </HintPath> </Reference>
-    <Reference Include="UnityEngine.Addressables">      <HintPath>lib\Unity.Addressables.dll        </HintPath> </Reference>
+    <Reference Include="Unity.TextMeshPro">             <HintPath>lib\Unity.TextMeshPro.dll         </HintPath> </Reference>
+    <Reference Include="Unity.Addressables">            <HintPath>lib\Unity.Addressables.dll        </HintPath> </Reference>
     <Reference Include="UnityEngine.UI">                <HintPath>lib\UnityEngine.UI.dll            </HintPath> </Reference>
-    <Reference Include="UnityEngine.UI.Extensions">     <HintPath>lib\UnityUIExtensions.dll         </HintPath> </Reference>
+    <Reference Include="UnityUIExtensions">             <HintPath>lib\UnityUIExtensions.dll         </HintPath> </Reference>
     <Reference Include="UnityEditor">                   <HintPath>lib\UnityEditor.dll               </HintPath> </Reference>
 
     <Reference Include="Ultrapain">                     <HintPath>lib\Ultrapain.dll                 </HintPath> </Reference>

--- a/assets/bundles/english.properties
+++ b/assets/bundles/english.properties
@@ -7,4 +7,4 @@ lobby.failed = [20][#FF341C]Couldn't find the lobby code on your clipboard.[][]\
 player.joined = [#32CD32]Player {0} joined![]
 player.died = [#FFA500]Player {0} died.[]
 player.left = [#FF341C]Player {0} left![]
-player.banned = [#FF341C]Player {0} was kicked![]
+player.banned = [#FF341C]Player {0} was banned![]

--- a/src/Jaket/Net/Networking.cs
+++ b/src/Jaket/Net/Networking.cs
@@ -113,7 +113,7 @@ public class Networking
             if (message == "#/d")
                 chat.ReceiveChatMessage($"<color=orange>Player {member.Name} died.</color>");
             else if (message.StartsWith("#/k") && ulong.TryParse(message.Substring(3), out ulong id))
-                chat.ReceiveChatMessage($"<color=red>Player {new Friend(id).Name} was kicked!</color>");
+                chat.ReceiveChatMessage($"<color=red>Player {new Friend(id).Name} was banned!</color>");
             else if (message.StartsWith("/tts "))
                 chat.ReceiveTTSMessage(member, message.Substring("/tts ".Length));
             else


### PR DESCRIPTION
"kicked" could make people think that the player can rejoin after being forced out of the lobby. "banned" on the other hand, which is what *does* happen, conveys that the player can *not* rejoin.
not a big change by any means but i still think that, with almost everything referring to it as a "ban" and it functioning as a temporary one until the lobby owner makes a new lobby, it can still help clear up a bit of confusion. 
(also sorry for the csproj commit :sob:)