### PR TITLE
Add credits museum to /level command

### DIFF
--- a/src/Jaket/Commands/Commands.cs
+++ b/src/Jaket/Commands/Commands.cs
@@ -75,7 +75,7 @@ public class Commands
                 Tools.Instantiate(Items.Prefabs[EntityType.PlushyOffset + index - EntityType.ItemOffset].gameObject, NewMovement.Instance.transform.position);
         });
 
-        Handler.Register("level", "<layer> <level> / sandbox / cyber grind", "Load the given level", args =>
+        Handler.Register("level", "<layer> <level> / sandbox / cyber grind / credits museum", "Load the given level", args =>
         {
             if (args.Length == 1 && args[0].Contains("-")) args = args[0].Split('-');
 
@@ -91,6 +91,11 @@ public class Commands
             {
                 Tools.Load("Endless");
                 chat.Receive("[#32CD32]The Cyber Grind is loading.");
+            }
+            else if (args.Length >= 1 && (args[0].ToLower().Contains("credits") || args[0].ToLower() == "museum"))
+            {
+                Tools.Load("CreditsMuseum2");
+                chat.Receive("[#32CD32]The Credits Museum is loading.");
             }
             else if (args.Length < 2)
                 chat.Receive($"[#FF341C]Insufficient number of arguments.");


### PR DESCRIPTION
(this is almost a direct copy of my post on the jaket discords suggestions feed, sorry)
### Allow someone to use /level to get to the credits museum using:
```
/level credits
/level museum
/level credits museum
``` 

## [A video demo of the changes to the /level command](https://youtu.be/AtN4iY8PUik)
## A screenshot of the /help message
![](https://github.com/user-attachments/assets/33eda9e3-e8ca-4fd2-9c1d-e8f1a458471e)
