### PR TITLE
Minor chat command fixes

### DIFF
--- a/src/Jaket/Commands/Command.cs
+++ b/src/Jaket/Commands/Command.cs
@@ -24,6 +24,6 @@ public class Command
         if (args == "")
             Handler([]);
         else
-            Handler(args.Split(' '));
+            Handler(args.Split(new[] { ' ' }, System.StringSplitOptions.RemoveEmptyEntries));
     }
 }

--- a/src/Jaket/Commands/Commands.cs
+++ b/src/Jaket/Commands/Commands.cs
@@ -90,7 +90,13 @@ public static class Commands
 
         Handler.Register("plushie", "<name>", "Spawn a plushie by name", args =>
         {
-            var name = args.Length == 0 ? null : args[0];
+            if (args.Length == 0)
+            {
+                chat.Receive("[red]Please provide a plushie name.");
+                return;
+            }
+
+            var name = args[0];
             int type = GameAssets.Plushies.IndexOf(n => n.Contains(name));
 
             if (type == -1)


### PR DESCRIPTION
1. Commands with multiple spaces created empty arguments, the commands now should work with multiple spaces and parse properly.  2. Shows a proper message if someone tries to use `/plushie` without a name picked. 