### PR TITLE
Added lobby utility commands and fix chat falling freeze

### DIFF
--- a/src/Jaket/Commands/Commands.cs
+++ b/src/Jaket/Commands/Commands.cs
@@ -50,6 +50,20 @@ public static class Commands
 
         Handler.Register("hello", "Resend the tips for new players", args => chat.SayHello());
 
+        Handler.Register("code", "Copy the lobby code to clipboard", args =>
+        {
+            if (LobbyController.Offline)
+                chat.Receive("[red]You aren't in a lobby yet.");
+            else
+                LobbyController.CopyCode();
+        });
+
+        Handler.Register("version", "Display Jaket and protocol versions", args => chat.Receive
+        (
+            $"[green]Jaket version:[] {Jaket.Version.Readable}\n" +
+            $"[green]Protocol version:[] {Jaket.Version.Protocol}"
+        ));
+
         Handler.Register("tts-volume", "\\[0-100]", "Set the volume of TTS", args =>
         {
             if (args.Length == 0)

--- a/src/Jaket/Input/Movement.cs
+++ b/src/Jaket/Input/Movement.cs
@@ -128,7 +128,7 @@ public class Movement : MonoSingleton<Movement>
             UI.Spectator.UpdateCamera(!nm.dead && Emotes.Ends);
         }
 
-        if (!nm.dead) nm.rb.constraints = UI.AnyDialog
+        if (!nm.dead) nm.rb.constraints = UI.AnyBlockingDialog
             ? RigidbodyConstraints.FreezeAll
             : Emotes.Current == 0xFF || Emotes.Current == 0x0B
                 ? RigidbodyConstraints.FreezeRotation

--- a/src/Jaket/UI/Dialogs/Chat.cs
+++ b/src/Jaket/UI/Dialogs/Chat.cs
@@ -52,7 +52,7 @@ public class Chat : Fragment
     /// <summary> Index of the currently viewed message in the history. </summary>
     private int index;
 
-    public Chat(Transform root) : base(root, "Chat", true, hide: () => Events.Post(() => UI.Chat.field.gameObject.SetActive(UI.Chat.Shown = false)))
+    public Chat(Transform root) : base(root, "Chat", true, hide: () => Events.Post(() => UI.Chat.field.gameObject.SetActive(UI.Chat.Shown = false)), freezesPlayer: false)
     {
         Events.OnLoad += () =>
         {

--- a/src/Jaket/UI/Lib/Fragment.cs
+++ b/src/Jaket/UI/Lib/Fragment.cs
@@ -11,6 +11,8 @@ public class Fragment
 {
     /// <summary> Whether the fragment is a dialog. </summary>
     public bool Dialog { get; private set; }
+    /// <summary> Whether showing this fragment freezes player physics. </summary>
+    public bool FreezesPlayer { get; private set; }
     /// <summary> Whether the fragment is visible. </summary>
     public bool Shown;
 
@@ -19,9 +21,10 @@ public class Fragment
     /// <summary> Vertical bar located on the left side of the fragment. </summary>
     public Bar Sidebar;
 
-    public Fragment(Transform root, string name, bool dialog, Prov<bool> cond = null, Runnable hide = null)
+    public Fragment(Transform root, string name, bool dialog, Prov<bool> cond = null, Runnable hide = null, bool freezesPlayer = true)
     {
         Content = Builder.Canvas(Create(name, root).transform, Dialog = dialog).transform;
+        FreezesPlayer = freezesPlayer;
 
         cond ??= () => true;
         hide ??= () => Content.gameObject.SetActive(Shown = false);

--- a/src/Jaket/UI/UI.cs
+++ b/src/Jaket/UI/UI.cs
@@ -20,6 +20,8 @@ public static class UI
 
     /// <summary> Whether any dialog is visible. </summary>
     public static bool AnyDialog => (Dialogs?.Any(d => d.Shown) ?? false) || (OptionsManager.Instance?.paused ?? false);
+    /// <summary> Whether any player-freezing dialog is visible. </summary>
+    public static bool AnyBlockingDialog => (Dialogs?.Any(d => d.Shown && d.FreezesPlayer) ?? false) || (OptionsManager.Instance?.paused ?? false);
 
     #region dialogs
 

--- a/src/Jaket/Version.cs
+++ b/src/Jaket/Version.cs
@@ -24,6 +24,8 @@ public static class Version
 
     /// <summary> Readable version includes beta tag. </summary>
     public static string Readable => DEBUG ? $"{CURRENT}-beta" : CURRENT;
+    /// <summary> Network protocol version used for multiplayer compatibility. </summary>
+    public static string Protocol => Readable;
     /// <summary> Hash of the current build's commit. </summary>
     public static string Hash => Assembly.GetCallingAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion[^40..^32];
 

--- a/src/Jaket/World/World.cs
+++ b/src/Jaket/World/World.cs
@@ -65,13 +65,13 @@ public class World
     #region data
 
     /// <summary> Number of bytes that the world data takes in a snapshot. </summary>
-    public static int BufferSize => 4 + (Pending ?? Scene).Length + Version.Readable.Length + performed.Count(b => b) * 2 + pos.Count(p => p != default) * 8;
+    public static int BufferSize => 4 + (Pending ?? Scene).Length + Version.Protocol.Length + performed.Count(b => b) * 2 + pos.Count(p => p != default) * 8;
 
     /// <summary> Writes the world data into a snapshot. </summary>
     public static void WriteData(Writer w)
     {
         w.String(Pending ?? Scene);
-        w.String(Version.Readable);
+        w.String(Version.Protocol);
 
         w.Byte((byte)PrefsManager.Instance.GetInt("difficulty"));
         w.Byte((byte)performed.Count(b => b));
@@ -93,7 +93,7 @@ public class World
         LoadScn(r.String());
         Reset();
 
-        if (r.String() != Version.Readable)
+        if (r.String() != Version.Protocol)
         {
             LobbyController.LeaveLobby();
             Log.Info("[LOBY] Left the lobby as the owner is outdated");


### PR DESCRIPTION
1. Added a /code command which instantly copies lobby code to clipboard 2. Added /version which prints the jaket version and protocol version into chat 3. introduced protocol replacing the readable concept across some parts of the code. Will be used for compatibility checks. (pretty much renamed readable to protocol in some parts.) 4. fixed a bug that caused players to freeze in midair when they opened chat. Also adjusted some piping to allow certain elements to freeze the player's physics. 

`Version.Protocol` aliases `Version.Readable` is mostly for intention and so further versions of the mod can allow next versions to retain playable compatibility with prior versions for non-sync breaking changes