### PR TITLE
Add client-side per-player muting

### DIFF
--- a/src/Jaket/Commands/Commands.cs
+++ b/src/Jaket/Commands/Commands.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 using Jaket.Assets;
 using Jaket.Content;
 using Jaket.Net;
+using Jaket.Net.Admin;
 using Jaket.UI;
 using Jaket.UI.Dialogs;
 
@@ -49,6 +50,49 @@ public static class Commands
         });
 
         Handler.Register("hello", "Resend the tips for new players", args => chat.SayHello());
+
+        Handler.Register("mute", "<name>", "Locally silence a player's voice, messages and sprays", args =>
+        {
+            if (LobbyController.Offline)
+            {
+                chat.Receive("[red]You aren't in a lobby yet.");
+                return;
+            }
+            if (args.Length == 0)
+            {
+                chat.Receive("[red]Please provide a player name.");
+                return;
+            }
+
+            int count = 0;
+            LobbyController.Lobby?.Members.Each(m => !m.IsMe && m.Name.Contains(args[0]), m =>
+            {
+                if (!Administration.Muted.Contains(m.AccId)) Administration.Muted.Add(m.AccId);
+                count++;
+            });
+            chat.Receive(count > 0 ? $"[green]Muted {count} player(s) matching \"{args[0]}\"." : $"[red]Couldn't find a player named {args[0]}.");
+        });
+
+        Handler.Register("unmute", "<name>", "Undo a local mute", args =>
+        {
+            if (LobbyController.Offline)
+            {
+                chat.Receive("[red]You aren't in a lobby yet.");
+                return;
+            }
+            if (args.Length == 0)
+            {
+                chat.Receive("[red]Please provide a player name.");
+                return;
+            }
+
+            int count = 0;
+            LobbyController.Lobby?.Members.Each(m => !m.IsMe && m.Name.Contains(args[0]), m =>
+            {
+                if (Administration.Muted.Remove(m.AccId)) count++;
+            });
+            chat.Receive(count > 0 ? $"[orange]Unmuted {count} player(s) matching \"{args[0]}\"." : $"[red]Couldn't find a muted player named {args[0]}.");
+        });
 
         Handler.Register("tts-volume", "\\[0-100]", "Set the volume of TTS", args =>
         {

--- a/src/Jaket/Commands/Commands.cs
+++ b/src/Jaket/Commands/Commands.cs
@@ -51,7 +51,7 @@ public static class Commands
 
         Handler.Register("hello", "Resend the tips for new players", args => chat.SayHello());
 
-        Handler.Register("mute", "<name>", "Locally silence a player's voice, messages and sprays", args =>
+        static void Silence(string[] args, bool mute)
         {
             if (LobbyController.Offline)
             {
@@ -67,32 +67,16 @@ public static class Commands
             int count = 0;
             LobbyController.Lobby?.Members.Each(m => !m.IsMe && m.Name.Contains(args[0]), m =>
             {
-                if (!Administration.Muted.Contains(m.AccId)) Administration.Muted.Add(m.AccId);
-                count++;
+                if (mute) { Administration.Mute(m.AccId); count++; }
+                else if (Administration.IsMuted(m.AccId)) { Administration.Unmute(m.AccId); count++; }
             });
-            chat.Receive(count > 0 ? $"[green]Muted {count} player(s) matching \"{args[0]}\"." : $"[red]Couldn't find a player named {args[0]}.");
-        });
 
-        Handler.Register("unmute", "<name>", "Undo a local mute", args =>
-        {
-            if (LobbyController.Offline)
-            {
-                chat.Receive("[red]You aren't in a lobby yet.");
-                return;
-            }
-            if (args.Length == 0)
-            {
-                chat.Receive("[red]Please provide a player name.");
-                return;
-            }
+            if (count > 0) chat.Receive(mute ? $"[green]Muted {count} player(s) matching \"{args[0]}\"." : $"[orange]Unmuted {count} player(s) matching \"{args[0]}\".");
+            else chat.Receive(mute ? $"[red]Couldn't find a player named {args[0]}." : $"[red]Couldn't find a muted player named {args[0]}.");
+        }
 
-            int count = 0;
-            LobbyController.Lobby?.Members.Each(m => !m.IsMe && m.Name.Contains(args[0]), m =>
-            {
-                if (Administration.Muted.Remove(m.AccId)) count++;
-            });
-            chat.Receive(count > 0 ? $"[orange]Unmuted {count} player(s) matching \"{args[0]}\"." : $"[red]Couldn't find a muted player named {args[0]}.");
-        });
+        Handler.Register("mute", "<name>", "Locally silence a player's voice, messages and sprays", args => Silence(args, true));
+        Handler.Register("unmute", "<name>", "Undo a local mute", args => Silence(args, false));
 
         Handler.Register("tts-volume", "\\[0-100]", "Set the volume of TTS", args =>
         {

--- a/src/Jaket/Net/Admin/Administration.cs
+++ b/src/Jaket/Net/Admin/Administration.cs
@@ -12,6 +12,8 @@ public static class Administration
     public static List<uint> Hidden = new();
     /// <summary> Identifiers of banned players. </summary>
     public static List<uint> Banned = new();
+    /// <summary> Identifiers of locally muted players, whose voice, messages and sprays are suppressed. </summary>
+    public static List<uint> Muted = new();
 
     /// <summary> Whether the local player is privileged. </summary>
     public static bool Privileged;

--- a/src/Jaket/Net/Admin/Administration.cs
+++ b/src/Jaket/Net/Admin/Administration.cs
@@ -24,7 +24,7 @@ public static class Administration
         Events.OnLobbyAction += () =>
         {
             // y'now, imma just type smth stupid here
-            if (LobbyController.Offline) return;
+            if (LobbyController.Offline) { Muted.Clear(); return; }
 
             subjects.Each(s => s?.Privilege.Update(LobbyConfig.Privileged, s.Id));
 
@@ -59,6 +59,23 @@ public static class Administration
 
         LobbyController.Lobby?.SendChatString("#/b" + id);
         LobbyConfig.Banned = Banned.ConvertAll(i => i.ToString());
+    }
+
+    /// <summary> Locally mutes the given player, suppressing their voice, messages and sprays. </summary>
+    public static void Mute(uint id) { if (!Muted.Contains(id)) Muted.Add(id); }
+
+    /// <summary> Removes the local mute from the given player. </summary>
+    public static void Unmute(uint id) => Muted.Remove(id);
+
+    /// <summary> Whether the given player is locally muted. </summary>
+    public static bool IsMuted(uint id) => Muted.Contains(id);
+
+    /// <summary> Toggles the local mute on the given player and returns the new state. </summary>
+    public static bool ToggleMute(uint id)
+    {
+        if (Muted.Remove(id)) return false;
+        Muted.Add(id);
+        return true;
     }
 
     /// <summary> Finds a subject with the given identifier or logs an error. </summary>

--- a/src/Jaket/Net/Networking.cs
+++ b/src/Jaket/Net/Networking.cs
@@ -150,6 +150,8 @@ public static class Networking
 
             else if (msg.StartsWith("#/t"))
             {
+                if (!member.IsMe && Administration.Muted.Contains(member.AccId)) return;
+
                 if (member.IsMe)
                     SamAPI.TryPlay(msg = msg[3..], LocalPlayer.Voice);
 
@@ -158,6 +160,7 @@ public static class Networking
 
                 UI.Chat.Receive(msg, GetColor(member), name, Chat.TTS_TAG);
             }
+            else if (!member.IsMe && Administration.Muted.Contains(member.AccId)) return;
             else
                 UI.Chat.Receive(msg, GetColor(member), name);
         };

--- a/src/Jaket/Net/Networking.cs
+++ b/src/Jaket/Net/Networking.cs
@@ -150,7 +150,7 @@ public static class Networking
 
             else if (msg.StartsWith("#/t"))
             {
-                if (!member.IsMe && Administration.Muted.Contains(member.AccId)) return;
+                if (!member.IsMe && Administration.IsMuted(member.AccId)) return;
 
                 if (member.IsMe)
                     SamAPI.TryPlay(msg = msg[3..], LocalPlayer.Voice);
@@ -160,7 +160,7 @@ public static class Networking
 
                 UI.Chat.Receive(msg, GetColor(member), name, Chat.TTS_TAG);
             }
-            else if (!member.IsMe && Administration.Muted.Contains(member.AccId)) return;
+            else if (!member.IsMe && Administration.IsMuted(member.AccId)) return;
             else
                 UI.Chat.Receive(msg, GetColor(member), name);
         };

--- a/src/Jaket/Sprays/SprayManager.cs
+++ b/src/Jaket/Sprays/SprayManager.cs
@@ -69,7 +69,7 @@ public static class SprayManager
             Bundle.Hud("spray.choose");
             return null;
         }
-        if (Administration.Hidden.Contains(owner) || !SpraySettings.Enabled) return null;
+        if (Administration.Hidden.Contains(owner) || Administration.Muted.Contains(owner) || !SpraySettings.Enabled) return null;
 
         return owner == AccId ? Selected : Remote.TryGetValue(owner, out var s) ? s : null;
     }

--- a/src/Jaket/Sprays/SprayManager.cs
+++ b/src/Jaket/Sprays/SprayManager.cs
@@ -69,7 +69,7 @@ public static class SprayManager
             Bundle.Hud("spray.choose");
             return null;
         }
-        if (Administration.Hidden.Contains(owner) || Administration.Muted.Contains(owner) || !SpraySettings.Enabled) return null;
+        if (Administration.Hidden.Contains(owner) || Administration.IsMuted(owner) || !SpraySettings.Enabled) return null;
 
         return owner == AccId ? Selected : Remote.TryGetValue(owner, out var s) ? s : null;
     }

--- a/src/Jaket/UI/Dialogs/PlayerList.cs
+++ b/src/Jaket/UI/Dialogs/PlayerList.cs
@@ -65,7 +65,16 @@ public class PlayerList : Fragment
                     s.ProfileButton(m, false);
                     s.FillButton(ModAssets.LobbyBan, red, () => Administration.Ban(m.AccId));
                 }
-                else s.ProfileButton(m, true);
+                else if (m.IsMe) s.ProfileButton(m, true);
+                else
+                {
+                    s.ProfileButton(m, false);
+                    s.FillButton("♪", Administration.Muted.Contains(m.AccId) ? red : gray, () =>
+                    {
+                        if (!Administration.Muted.Remove(m.AccId)) Administration.Muted.Add(m.AccId);
+                        Rebuild();
+                    });
+                }
             }));
             if (!LobbyController.IsOwner) return;
 

--- a/src/Jaket/UI/Dialogs/PlayerList.cs
+++ b/src/Jaket/UI/Dialogs/PlayerList.cs
@@ -60,20 +60,16 @@ public class PlayerList : Fragment
                     s.ProfileButton(m, false);
                     s.FillButton(ModAssets.LobbyOwner, yellow, () => Bundle.Hud("player-list.owner"));
                 }
-                else if (LobbyController.IsOwner)
-                {
-                    s.ProfileButton(m, false);
-                    s.FillButton(ModAssets.LobbyBan, red, () => Administration.Ban(m.AccId));
-                }
                 else if (m.IsMe) s.ProfileButton(m, true);
                 else
                 {
                     s.ProfileButton(m, false);
-                    s.FillButton("♪", Administration.Muted.Contains(m.AccId) ? red : gray, () =>
+                    s.FillButton("♪", Administration.IsMuted(m.AccId) ? red : gray, () =>
                     {
-                        if (!Administration.Muted.Remove(m.AccId)) Administration.Muted.Add(m.AccId);
+                        Administration.ToggleMute(m.AccId);
                         Rebuild();
                     });
+                    if (LobbyController.IsOwner) s.FillButton(ModAssets.LobbyBan, red, () => Administration.Ban(m.AccId));
                 }
             }));
             if (!LobbyController.IsOwner) return;


### PR DESCRIPTION
If a player is being annoying and spamming there is no solution, now we can mute them and it'll block their, chat, spray and tts. It can be done via button in the menu and text command /mute and /unmute

1 New `Administration.Muted` list
2 A toggle button on each player's row in the `F2` player list
3 `/mute <name>` and `/unmute <name>` commands

Tested in game and it seems to work.