### PR TITLE
Respawn host at level start instead of reloading on checkpointless death

### DIFF
--- a/src/Jaket/Input/Movement.cs
+++ b/src/Jaket/Input/Movement.cs
@@ -32,22 +32,11 @@ public class Movement : MonoSingleton<Movement>
     /// <summary> Hold time of the emote wheel key. </summary>
     private float holdTime;
 
-    /// <summary> Position and rotation of the level's start, captured on load to respawn the host without reloading the world. </summary>
-    private static Vector3 spawnPos;
-    private static float spawnRot;
-
     #region general
 
     private void Start()
     {
         Events.OnLoad += () => UpdateState(true);
-        Events.OnLoad += () => Events.Post(() =>
-        {
-            if (Scene == "Main Menu") return;
-
-            spawnPos = nm.transform.position;
-            spawnRot = nm.transform.eulerAngles.y;
-        });
         Events.EveryHalf += () =>
         {
             if (ch.cheatsEnabled && LobbyController.Online && !Administration.Privileged)
@@ -205,14 +194,8 @@ public class Movement : MonoSingleton<Movement>
     /// <summary> Respawns Cyber Grind players and flashes the screen. </summary>
     public static void CyberRespawn() => Respawn(new(0f, 80f, 62.5f), 0f, true);
 
-    /// <summary> Respawns the player at the level's start instead of reloading the whole world. </summary>
-    public static void RespawnAtStart()
-    {
-        // the game records the position where the level's start trigger fired, which is correct everywhere, including
-        // levels like 0-1 that teleport the player to an alternate start after load; fall back to the captured transform
-        var pos = PlayerActivator.lastActivatedPosition;
-        Respawn(pos == default ? spawnPos : pos, spawnRot);
-    }
+    /// <summary> Respawns the player at the level's start (recorded by the game's start trigger, correct even on levels like 0-1) instead of reloading the whole world. </summary>
+    public static void RespawnAtStart() => Respawn(PlayerActivator.lastActivatedPosition, nm.transform.eulerAngles.y);
 
     /// <summary> Kills the player immediately. </summary>
     public static void Suicide() => nm.GetHurt(nm.hp, true, 0f, instablack: true, ignoreInvincibility: true);

--- a/src/Jaket/Input/Movement.cs
+++ b/src/Jaket/Input/Movement.cs
@@ -32,11 +32,22 @@ public class Movement : MonoSingleton<Movement>
     /// <summary> Hold time of the emote wheel key. </summary>
     private float holdTime;
 
+    /// <summary> Position and rotation of the level's start, captured on load to respawn the host without reloading the world. </summary>
+    private static Vector3 spawnPos;
+    private static float spawnRot;
+
     #region general
 
     private void Start()
     {
         Events.OnLoad += () => UpdateState(true);
+        Events.OnLoad += () => Events.Post(() =>
+        {
+            if (Scene == "Main Menu") return;
+
+            spawnPos = nm.transform.position;
+            spawnRot = nm.transform.eulerAngles.y;
+        });
         Events.EveryHalf += () =>
         {
             if (ch.cheatsEnabled && LobbyController.Online && !Administration.Privileged)
@@ -193,6 +204,15 @@ public class Movement : MonoSingleton<Movement>
 
     /// <summary> Respawns Cyber Grind players and flashes the screen. </summary>
     public static void CyberRespawn() => Respawn(new(0f, 80f, 62.5f), 0f, true);
+
+    /// <summary> Respawns the player at the level's start instead of reloading the whole world. </summary>
+    public static void RespawnAtStart()
+    {
+        // the game records the position where the level's start trigger fired, which is correct everywhere, including
+        // levels like 0-1 that teleport the player to an alternate start after load; fall back to the captured transform
+        var pos = PlayerActivator.lastActivatedPosition;
+        Respawn(pos == default ? spawnPos : pos, spawnRot);
+    }
 
     /// <summary> Kills the player immediately. </summary>
     public static void Suicide() => nm.GetHurt(nm.hp, true, 0f, instablack: true, ignoreInvincibility: true);

--- a/src/Jaket/UI/Fragments/Spectator.cs
+++ b/src/Jaket/UI/Fragments/Spectator.cs
@@ -138,7 +138,19 @@ public class Spectator : Fragment
 
     [DynamicPatch(typeof(StatsManager), nameof(StatsManager.Restart))]
     [Prefix]
-    static bool Restart() => !nm.deathSequence.gameObject.activeSelf && !UI.Spectator.Shown;
+    static bool Restart()
+    {
+        if (nm.deathSequence.gameObject.activeSelf || UI.Spectator.Shown) return false;
+
+        // soft-respawn the host instead of reloading the scene, which would reset the lobby for everyone
+        if (LobbyController.Online && LobbyController.IsOwner && !StatsManager.Instance.currentCheckPoint)
+        {
+            StatsManager.Instance.restarts++;
+            Movement.RespawnAtStart();
+            return false;
+        }
+        return true;
+    }
 
     [DynamicPatch(typeof(DeathSequence), nameof(DeathSequence.EndSequence))]
     [Prefix]


### PR DESCRIPTION
Closes #187

When the host dies without a checkpoint, the game reloads the whole level, which sends the entire lobby back to the start. This fix makes the host respawn at the level's start instead.

Patched `StatsManager.Restart` so if the host has no checkpoint, it'll respawn them instead when they press R and count the restart instead of reloading the entire level for everyone. Clients and checkpoint respawns and the "Restart Mission" buttons are unaffected. This also means PVP enabled matches won't break if the host dies before a checkpoint. Also this means it'll properly be able to count deaths/restarts properly for gamemodes that might use it.

I saw @PyroGabrielKotzell's concern about the lack of recording a respawn point so instead of spawning a checkpoint at the start of every level I found out the game has a `PlayerActivator.lastActivatedPosition`  which marks the level's start trigger being fired, so it's correct in every single level every time. For a backup we also have a snapshot recorded position made when players load into a level the host is sent back to instead. This usually ends up being the elevator but this backup breaks on 0-1 which is why I suggest `PlayerActivator.lastActivatedPosition` instead.

Users can still use the "Restart Mission" button to reload a level which is probably better in the long run.