### PR TITLE
Sync the gasoline, projectiles, stains, enemies oiled up and ignition

### DIFF
--- a/src/Jaket/Assets/GameAssets.cs
+++ b/src/Jaket/Assets/GameAssets.cs
@@ -232,6 +232,8 @@ public static class GameAssets
         "Attacks and Projectiles/Projectile.prefab",
         "Attacks and Projectiles/Projectile Beamable.prefab",
         "Attacks and Projectiles/Projectile Explosive.prefab",
+        "Attacks and Projectiles/GasolineProjectile.prefab",
+        "Attacks and Projectiles/GasolineStain.prefab",
     };
 
     /// <summary> List of internal paths of all explosions. </summary>

--- a/src/Jaket/Content/EntityType.cs
+++ b/src/Jaket/Content/EntityType.cs
@@ -209,6 +209,8 @@ public enum EntityType : byte
     ProjectileHell,
     ProjectileBeam,
     ProjectileExpl,
+    Gasoline,
+    GasolineStain,
 
     #endregion
     #region explosions
@@ -247,7 +249,7 @@ public static class EntityTypes
     public static bool IsHitscan   (this EntityType type) => type >= EntityType.Beam         && type <= EntityType.BeamHammer;
 
     /// <summary> Whether the type is a projectile. </summary>
-    public static bool IsProjectile(this EntityType type) => type >= EntityType.Shell        && type <= EntityType.ProjectileExpl;
+    public static bool IsProjectile(this EntityType type) => type >= EntityType.Shell        && type <= EntityType.GasolineStain;
 
     /// <summary> Whether the type is an explosion. </summary>
     public static bool IsExplosion (this EntityType type) => type >= EntityType.Shockwave    && type <= EntityType.HammerParticleHeavy;

--- a/src/Jaket/Content/PacketType.cs
+++ b/src/Jaket/Content/PacketType.cs
@@ -39,5 +39,8 @@ public enum PacketType : byte
     CyberAction,
 
     /// <summary> Player voted for an option. Voting can be different: skip of a cutscene, dialog or choice of an option. </summary>
-    Vote
+    Vote,
+
+    /// <summary> Contains data of a gasoline ignition. </summary>
+    Ignition
 }

--- a/src/Jaket/Content/PacketType.cs
+++ b/src/Jaket/Content/PacketType.cs
@@ -42,5 +42,7 @@ public enum PacketType : byte
     Vote,
 
     /// <summary> Contains data of a gasoline ignition. </summary>
-    Ignition
+    Ignition,
+    /// <summary> Contains data of sprayed gasoline droplets. </summary>
+    Gasoline
 }

--- a/src/Jaket/Net/Admin/Subject.cs
+++ b/src/Jaket/Net/Admin/Subject.cs
@@ -24,7 +24,8 @@ public class Subject
     defpool = new(24),
     project = new(24),
     flashes = new(48),
-    harpoon = new(4);
+    harpoon = new(4),
+    gasstns = new(256);
 
     public Subject(uint id) => Id = id;
 
@@ -85,7 +86,9 @@ public class Subject
         {
             if (type == EntityType.Screwdriver)
                 harpoon.Add(entity);
-            else if (type == EntityType.Shell || type >= EntityType.NailCommon && type <= EntityType.NailHeated || type >= EntityType.ProjectileHell && type <= EntityType.ProjectileExpl)
+            else if (type == EntityType.GasolineStain)
+                gasstns.Add(entity);
+            else if (type == EntityType.Shell || type >= EntityType.NailCommon && type <= EntityType.NailHeated || type >= EntityType.ProjectileHell && type <= EntityType.Gasoline)
                 flashes.Add(entity);
             else
                 project.Add(entity);

--- a/src/Jaket/Net/Admin/Subject.cs
+++ b/src/Jaket/Net/Admin/Subject.cs
@@ -88,7 +88,7 @@ public class Subject
                 harpoon.Add(entity);
             else if (type == EntityType.GasolineStain)
                 gasstns.Add(entity);
-            else if (type == EntityType.Shell || type >= EntityType.NailCommon && type <= EntityType.NailHeated || type >= EntityType.ProjectileHell && type <= EntityType.Gasoline)
+            else if (type == EntityType.Shell || type >= EntityType.NailCommon && type <= EntityType.NailHeated || type >= EntityType.ProjectileHell && type <= EntityType.ProjectileExpl)
                 flashes.Add(entity);
             else
                 project.Add(entity);

--- a/src/Jaket/Net/Endpoints/Client.cs
+++ b/src/Jaket/Net/Endpoints/Client.cs
@@ -93,6 +93,8 @@ public class Client : Endpoint, IConnectionManager
 
         Listen(PacketType.Ignition, Stain.Ignite);
 
+        Listen(PacketType.Gasoline, (con, sender, r, s) => Gasoline.Spawn(r, s));
+
         /*
         Listen(PacketType.Vote, r => Votes.UpdateVote(r.Id(), r.Byte()));
         */

--- a/src/Jaket/Net/Endpoints/Client.cs
+++ b/src/Jaket/Net/Endpoints/Client.cs
@@ -91,6 +91,8 @@ public class Client : Endpoint, IConnectionManager
 
         Listen(PacketType.WorldAction, r => World.Perform(r.Byte(), new(r.Float(), r.Float())));
 
+        Listen(PacketType.Ignition, Stain.Ignite);
+
         /*
         Listen(PacketType.Vote, r => Votes.UpdateVote(r.Id(), r.Byte()));
         */

--- a/src/Jaket/Net/Endpoints/Server.cs
+++ b/src/Jaket/Net/Endpoints/Server.cs
@@ -113,6 +113,12 @@ public class Server : Endpoint, ISocketManager
             Redirect(r, s, con);
         });
 
+        Listen(PacketType.Ignition, (con, sender, r, s) =>
+        {
+            Stain.Ignite(r);
+            Redirect(r, s, con);
+        });
+
         /*
         Listen(PacketType.Vote, (con, sender, r, s) =>
         {

--- a/src/Jaket/Net/Endpoints/Server.cs
+++ b/src/Jaket/Net/Endpoints/Server.cs
@@ -119,6 +119,12 @@ public class Server : Endpoint, ISocketManager
             Redirect(r, s, con);
         });
 
+        Listen(PacketType.Gasoline, (con, sender, r, s) =>
+        {
+            Gasoline.Spawn(r, s);
+            Redirect(r, s, con);
+        });
+
         /*
         Listen(PacketType.Vote, (con, sender, r, s) =>
         {

--- a/src/Jaket/Net/Entity.cs
+++ b/src/Jaket/Net/Entity.cs
@@ -31,6 +31,9 @@ public abstract class Entity
         set => LastHidden = value ? Time.time : float.PositiveInfinity;
     }
 
+    /// <summary> Whether the entity is dormant, such entities are not synchronized until woken up; suits static entities, as packets are sent reliably. </summary>
+    public virtual bool Dormant => false;
+
     public Entity(uint id, EntityType type) { Owner = Id = id; Type = type; Hidden = false; }
 
     /// <summary> Pushes the entity into networking pool. </summary>

--- a/src/Jaket/Net/Pools.cs
+++ b/src/Jaket/Net/Pools.cs
@@ -87,9 +87,9 @@ public class Pools
     public void Player(Pred<Player> pred, Cons<Player> cons) => Each(0, 1, e => { if (!e.Hidden && e is Player p && pred(p)) cons(p); });
 
     /// <summary> Iterates each visible entity in the given server pool. </summary>
-    public void ServerPool(int i, int s, Cons<Entity> cons)  => Each(i, s, e => { if (!e.Hidden) cons(e); });
+    public void ServerPool(int i, int s, Cons<Entity> cons)  => Each(i, s, e => { if (!e.Hidden && !e.Dormant) cons(e); });
     /// <summary> Iterates each visible entity in the given client pool. </summary>
-    public void ClientPool(int i, int s, Cons<Entity> cons)  => Each(i, s, e => { if (!e.Hidden && e.IsOwner) cons(e); });
+    public void ClientPool(int i, int s, Cons<Entity> cons)  => Each(i, s, e => { if (!e.Hidden && e.IsOwner && !e.Dormant) cons(e); });
 
     /// <summary> Counts the number of entities that are suitable for the given predicate. </summary>
     public int Count(Pred<Entity> pred)

--- a/src/Jaket/Net/Types/Projectiles/Gasoline.cs
+++ b/src/Jaket/Net/Types/Projectiles/Gasoline.cs
@@ -1,0 +1,56 @@
+namespace Jaket.Net.Types;
+
+using UnityEngine;
+
+using Jaket.Content;
+using Jaket.Harmony;
+
+/// <summary> Tangible entity of the gasoline projectile type. </summary>
+public class Gasoline : Projectile
+{
+    Agent agent;
+
+    public Gasoline(uint id, EntityType type) : base(id, type, true, true, true) { }
+
+    #region logic
+
+    /// <summary> Gasoline is always green, no matter the team of the player that sprayed it. </summary>
+    public override void Paint(Renderer renderer) { }
+
+    public override void Assign(Agent agent)
+    {
+        base.Assign(this.agent = agent);
+
+        agent.Run(MasterKill, 10f);
+
+        // hits are processed by the owner of the projectile and then synced via gasoline stains and enemy fuel
+        if (IsOwner)
+            agent.gameObject.AddComponent<Sentinel>().Patron = this;
+        else
+            agent.Rem<SphereCollider>();
+    }
+
+    #endregion
+    #region harmony
+
+    [DynamicPatch(typeof(GasolineProjectile), nameof(GasolineProjectile.Start))]
+    [Prefix]
+    static void Start(GasolineProjectile __instance)
+    {
+        if (__instance) Entities.Projectiles.Sync(__instance.gameObject);
+    }
+
+    #endregion
+
+    /// <summary> Component that reports the destruction of its object to the entity. </summary>
+    public class Sentinel : MonoBehaviour
+    {
+        /// <summary> Entity that owns the sentinel and has to be killed on destruction. </summary>
+        public Entity Patron;
+
+        void OnDestroy()
+        {
+            if (gameObject.scene.isLoaded && !Networking.Loading && LobbyController.Online && Patron.IsOwner && !Patron.Hidden) Patron.Kill();
+        }
+    }
+}

--- a/src/Jaket/Net/Types/Projectiles/Gasoline.cs
+++ b/src/Jaket/Net/Types/Projectiles/Gasoline.cs
@@ -1,56 +1,71 @@
 namespace Jaket.Net.Types;
 
+using System.Collections.Generic;
 using UnityEngine;
 
 using Jaket.Content;
 using Jaket.Harmony;
+using Jaket.IO;
 
-/// <summary> Tangible entity of the gasoline projectile type. </summary>
-public class Gasoline : Projectile
+/// <summary>
+/// Gasoline droplets are not entities: their flight is pure ballistics, so one-shot spawn events suffice, just like hitscans.
+/// Hits are processed by the owner of the droplets and synced via gasoline stains and enemy fuel.
+/// </summary>
+public static class Gasoline
 {
-    Agent agent;
+    /// <summary> Maximum number of droplets per batch, protects against malformed packets. </summary>
+    public const int BATCH_SIZE = 8;
 
-    public Gasoline(uint id, EntityType type) : base(id, type, true, true, true) { }
+    /// <summary> Positions and velocities of the droplets sprayed by the local player since the last tick. </summary>
+    private static List<Vector3> batch = new();
 
-    #region logic
-
-    /// <summary> Gasoline is always green, no matter the team of the player that sprayed it. </summary>
-    public override void Paint(Renderer renderer) { }
-
-    public override void Assign(Agent agent)
+    /// <summary> Sends the accumulated droplets to other players. </summary>
+    public static void Flush()
     {
-        base.Assign(this.agent = agent);
-
-        agent.Run(MasterKill, 10f);
-
-        // hits are processed by the owner of the projectile and then synced via gasoline stains and enemy fuel
-        if (IsOwner)
-            agent.gameObject.AddComponent<Sentinel>().Patron = this;
-        else
-            agent.Rem<SphereCollider>();
+        if (LobbyController.Online && batch.Count > 0) Networking.Send(PacketType.Gasoline, batch.Count * 12, w => batch.Each(v => w.Vector(v)));
+        batch.Clear();
     }
 
-    #endregion
+    /// <summary> Spawns the received droplets, they are purely visual. </summary>
+    public static void Spawn(Reader r, int size)
+    {
+        for (int n = Mathf.Min((size - 1) / 24, BATCH_SIZE); n > 0; n--)
+        {
+            var obj = Entities.Projectiles.Make(EntityType.Gasoline, r.Vector());
+            obj.name = "R#Gasoline";
+
+            obj.GetComponent<Rigidbody>().velocity = r.Vector();
+            obj.AddComponent<Droplet>();
+        }
+    }
+
     #region harmony
 
     [DynamicPatch(typeof(GasolineProjectile), nameof(GasolineProjectile.Start))]
     [Prefix]
-    static void Start(GasolineProjectile __instance)
+    static void Fired(GasolineProjectile __instance)
     {
-        if (__instance) Entities.Projectiles.Sync(__instance.gameObject);
+        if (__instance && __instance.name[0] != 'R')
+        {
+            batch.Add(__instance.transform.position);
+            batch.Add(__instance.rb.velocity);
+        }
     }
+
+    [DynamicPatch(typeof(GasolineProjectile), nameof(GasolineProjectile.OnTriggerEnter))]
+    [Prefix]
+    static bool Touch(GasolineProjectile __instance) => __instance.name[0] != 'R';
 
     #endregion
 
-    /// <summary> Component that reports the destruction of its object to the entity. </summary>
-    public class Sentinel : MonoBehaviour
+    /// <summary> Component that imitates the impact behavior of a real droplet without producing any effects. </summary>
+    public class Droplet : MonoBehaviour
     {
-        /// <summary> Entity that owns the sentinel and has to be killed on destruction. </summary>
-        public Entity Patron;
+        void Start() => Destroy(gameObject, 10f);
 
-        void OnDestroy()
+        void OnTriggerEnter(Collider other)
         {
-            if (gameObject.scene.isLoaded && !Networking.Loading && LobbyController.Online && Patron.IsOwner && !Patron.Hidden) Patron.Kill();
+            if (LayerMaskDefaults.IsMatchingLayer(other.gameObject.layer, LMD.Environment)) Destroy(gameObject);
         }
     }
 }

--- a/src/Jaket/Net/Types/Projectiles/Stain.cs
+++ b/src/Jaket/Net/Types/Projectiles/Stain.cs
@@ -68,7 +68,7 @@ public class Stain : OwnableEntity
         OnTransfer = () =>
         {
             Wake();
-            if (IsOwner && agent) agent.gameObject.GetOrAddComponent<Gasoline.Sentinel>().Patron = this;
+            if (IsOwner && agent) agent.gameObject.GetOrAddComponent<Sentinel>().Patron = this;
         };
 
         if (IsOwner)
@@ -146,4 +146,16 @@ public class Stain : OwnableEntity
     }
 
     #endregion
+
+    /// <summary> Component that reports the destruction of its object to the entity. </summary>
+    public class Sentinel : MonoBehaviour
+    {
+        /// <summary> Entity that owns the sentinel and has to be killed on destruction. </summary>
+        public Entity Patron;
+
+        void OnDestroy()
+        {
+            if (gameObject.scene.isLoaded && !Networking.Loading && LobbyController.Online && Patron.IsOwner && !Patron.Hidden) Patron.Kill();
+        }
+    }
 }

--- a/src/Jaket/Net/Types/Projectiles/Stain.cs
+++ b/src/Jaket/Net/Types/Projectiles/Stain.cs
@@ -14,8 +14,16 @@ public class Stain : OwnableEntity
 
     /// <summary> Placement of the stain, it never moves relative to the surface it is attached to. </summary>
     private Vector3 pos, rot;
+    /// <summary> Number of snapshots written since the last wake-up. </summary>
+    private int sent;
 
     public Stain(uint id, EntityType type) : base(id, type) { }
+
+    /// <summary> Stains never change, so they fall asleep once reliably delivered to everyone. </summary>
+    public override bool Dormant => sent >= 16;
+
+    /// <summary> Wakes the stain up, forcing it to broadcast itself again. </summary>
+    public void Wake() => sent = 0;
 
     #region snapshot
 
@@ -23,6 +31,7 @@ public class Stain : OwnableEntity
 
     public override void Write(Writer w)
     {
+        sent++;
         WriteOwner(ref w);
 
         if (IsOwner)
@@ -58,6 +67,7 @@ public class Stain : OwnableEntity
 
         OnTransfer = () =>
         {
+            Wake();
             if (IsOwner && agent) agent.gameObject.GetOrAddComponent<Gasoline.Sentinel>().Patron = this;
         };
 

--- a/src/Jaket/Net/Types/Projectiles/Stain.cs
+++ b/src/Jaket/Net/Types/Projectiles/Stain.cs
@@ -1,0 +1,139 @@
+namespace Jaket.Net.Types;
+
+using UnityEngine;
+
+using Jaket.Content;
+using Jaket.Harmony;
+using Jaket.IO;
+
+/// <summary> Tangible entity of the gasoline stain type. </summary>
+public class Stain : OwnableEntity
+{
+    Agent agent;
+    GasolineStain stain;
+
+    /// <summary> Placement of the stain, it never moves relative to the surface it is attached to. </summary>
+    private Vector3 pos, rot;
+
+    public Stain(uint id, EntityType type) : base(id, type) { }
+
+    #region snapshot
+
+    public override int BufferSize => 33;
+
+    public override void Write(Writer w)
+    {
+        WriteOwner(ref w);
+
+        if (IsOwner)
+        {
+            w.Vector(agent ? agent.Position : pos);
+            w.Vector(agent ? agent.Rotation : rot);
+        }
+        else
+        {
+            w.Vector(pos);
+            w.Vector(rot);
+        }
+    }
+
+    public override void Read(Reader r)
+    {
+        if (ReadOwner(ref r)) return;
+
+        pos = r.Vector();
+        rot = r.Vector();
+    }
+
+    #endregion
+    #region logic
+
+    public override void Create() => Assign(Entities.Projectiles.Make(Type, pos).AddComponent<Agent>());
+
+    public override void Assign(Agent agent)
+    {
+        base.Assign(this.agent = agent);
+
+        agent.Get(out stain);
+
+        OnTransfer = () =>
+        {
+            if (IsOwner && agent) agent.gameObject.GetOrAddComponent<Gasoline.Sentinel>().Patron = this;
+        };
+
+        if (IsOwner)
+        {
+            pos = agent.Position;
+            rot = agent.Rotation;
+        }
+        else
+        {
+            agent.Rotation = rot;
+            Attach();
+        }
+        OnTransfer();
+    }
+
+    /// <summary> Finds the surface beneath the stain and attaches the stain to it. </summary>
+    private void Attach()
+    {
+        var forward = agent.transform.forward;
+
+        if (Physics.Raycast(agent.Position - forward, forward, out var hit, 3f, EnvMask))
+        {
+            // clipping depends on local graphics settings, so each machine resolves it on its own
+            bool clip = PostProcessV2_Handler.Instance.usedComputeShadersAtStart
+                && !(hit.collider.TryGetComponent(out MeshRenderer r) && (r.sharedMaterial?.IsKeywordEnabled("VERTEX_DISPLACEMENT") ?? false));
+
+            stain.AttachTo(hit.collider, clip);
+        }
+        else Dest(agent.gameObject);
+    }
+
+    public override void Update(float delta) { }
+
+    public override void Damage(Reader r) { }
+
+    public override void Killed(Reader r, int left)
+    {
+        Hidden = true;
+        if (agent) Dest(agent.gameObject);
+    }
+
+    #endregion
+    #region ignition
+
+    /// <summary> Whether an ignition is being applied from the network. </summary>
+    public static bool Igniting;
+
+    /// <summary> Applies a remote ignition to the local stains. </summary>
+    public static void Ignite(Reader r)
+    {
+        Igniting = true;
+        StainVoxelManager.Instance.TryIgniteAt(r.Vector(), r.Byte());
+        Igniting = false;
+    }
+
+    #endregion
+    #region harmony
+
+    [DynamicPatch(typeof(GasolineStain), nameof(GasolineStain.AttachTo))]
+    [Postfix]
+    static void Attach(GasolineStain __instance)
+    {
+        if (__instance) Entities.Projectiles.Sync(__instance.gameObject);
+    }
+
+    [DynamicPatch(typeof(StainVoxelManager), nameof(StainVoxelManager.TryIgniteAt), typeof(Vector3), typeof(int))]
+    [Postfix]
+    static void Ignite(Vector3 worldPosition, int checkSize, bool __result)
+    {
+        if (__result && !Igniting) Networking.Send(PacketType.Ignition, 13, w =>
+        {
+            w.Vector(worldPosition);
+            w.Byte((byte)checkSize);
+        });
+    }
+
+    #endregion
+}

--- a/src/Jaket/Net/Types/Subtypes/Enemy.cs
+++ b/src/Jaket/Net/Types/Subtypes/Enemy.cs
@@ -46,6 +46,19 @@ public abstract class Enemy : OwnableEntity
         w.Bool(enraged);
     });
 
+    /// <summary> Whether fuel is being applied from the network. </summary>
+    public static bool Oiling;
+
+    /// <summary> Synchronizes the gasoline fuel applied to the enemy; the sender has already applied it locally. </summary>
+    public void Oil(float amount) => Kill(8, w =>
+    {
+        w.Bool(false);
+        w.Bool(false);
+        w.Bool(false);
+        w.Bool(true);
+        w.Float(amount);
+    }, locally: false);
+
     public virtual Transform WeakPoint => enemyId.weakPoint?.transform ?? agent.transform;
 
     public virtual EnemyTarget Tracked => enemyId.target = IsOwner ? EnemyTarget.TrackPlayerIfAllowed() : player.Value?.Target;
@@ -149,6 +162,13 @@ public abstract class Enemy : OwnableEntity
         }
 
         if (left >= 3 && r.Bool()) Rage(r.Bool());
+
+        if (left == 8 && r.Bool())
+        {
+            Oiling = true;
+            enemyId.AddFlammable(r.Float());
+            Oiling = false;
+        }
     }
 
     public virtual void Killed(bool explode)
@@ -187,6 +207,13 @@ public abstract class Enemy : OwnableEntity
     static void Death(EnemyIdentifier __instance)
     {
         if (__instance.TryGetEntity(out Enemy e) && !e.Hidden) e.Kill(2, w => { w.Bool(true); w.Bool(false); });
+    }
+
+    [DynamicPatch(typeof(EnemyIdentifier), nameof(EnemyIdentifier.AddFlammable))]
+    [Postfix]
+    static void Oiled(EnemyIdentifier __instance, float amount)
+    {
+        if (!Oiling && __instance.TryGetEntity(out Enemy e) && !e.Hidden) e.Oil(amount);
     }
 
     [DynamicPatch(typeof(EnemyIdentifier), nameof(EnemyIdentifier.UpdateTarget))]

--- a/src/Jaket/Net/Vendors/Projectiles.cs
+++ b/src/Jaket/Net/Vendors/Projectiles.cs
@@ -29,11 +29,11 @@ public class Projectiles : Vendor
         for (EntityType i = EntityType.Rocket;         i <= EntityType.Rocket;         i++) Vendor.Suppliers[(byte)i] = (id, type) => new Rocket     (id, type);
         for (EntityType i = EntityType.Cannonball;     i <= EntityType.Cannonball;     i++) Vendor.Suppliers[(byte)i] = (id, type) => new Cannon     (id, type);
         for (EntityType i = EntityType.ProjectileHell; i <= EntityType.ProjectileExpl; i++) Vendor.Suppliers[(byte)i] = (id, type) => new Shell      (id, type);
-        for (EntityType i = EntityType.Gasoline;       i <= EntityType.Gasoline;       i++) Vendor.Suppliers[(byte)i] = (id, type) => new Gasoline   (id, type);
         for (EntityType i = EntityType.GasolineStain;  i <= EntityType.GasolineStain;  i++) Vendor.Suppliers[(byte)i] = (id, type) => new Stain      (id, type);
 
         Events.OnTeamChange += () => Networking.Entities.Alive<Projectile>(p => p.UpdateIgnore());
         Events.OnMemberJoin += _ => Networking.Entities.Alive<Stain>(s => s.Wake());
+        Events.EveryTick    += Gasoline.Flush;
     }
 
     public EntityType Type(GameObject obj) => Vendor.Find

--- a/src/Jaket/Net/Vendors/Projectiles.cs
+++ b/src/Jaket/Net/Vendors/Projectiles.cs
@@ -33,6 +33,7 @@ public class Projectiles : Vendor
         for (EntityType i = EntityType.GasolineStain;  i <= EntityType.GasolineStain;  i++) Vendor.Suppliers[(byte)i] = (id, type) => new Stain      (id, type);
 
         Events.OnTeamChange += () => Networking.Entities.Alive<Projectile>(p => p.UpdateIgnore());
+        Events.OnMemberJoin += _ => Networking.Entities.Alive<Stain>(s => s.Wake());
     }
 
     public EntityType Type(GameObject obj) => Vendor.Find

--- a/src/Jaket/Net/Vendors/Projectiles.cs
+++ b/src/Jaket/Net/Vendors/Projectiles.cs
@@ -29,6 +29,8 @@ public class Projectiles : Vendor
         for (EntityType i = EntityType.Rocket;         i <= EntityType.Rocket;         i++) Vendor.Suppliers[(byte)i] = (id, type) => new Rocket     (id, type);
         for (EntityType i = EntityType.Cannonball;     i <= EntityType.Cannonball;     i++) Vendor.Suppliers[(byte)i] = (id, type) => new Cannon     (id, type);
         for (EntityType i = EntityType.ProjectileHell; i <= EntityType.ProjectileExpl; i++) Vendor.Suppliers[(byte)i] = (id, type) => new Shell      (id, type);
+        for (EntityType i = EntityType.Gasoline;       i <= EntityType.Gasoline;       i++) Vendor.Suppliers[(byte)i] = (id, type) => new Gasoline   (id, type);
+        for (EntityType i = EntityType.GasolineStain;  i <= EntityType.GasolineStain;  i++) Vendor.Suppliers[(byte)i] = (id, type) => new Stain      (id, type);
 
         Events.OnTeamChange += () => Networking.Entities.Alive<Projectile>(p => p.UpdateIgnore());
     }
@@ -36,7 +38,7 @@ public class Projectiles : Vendor
     public EntityType Type(GameObject obj) => Vendor.Find
     (
         EntityType.Shell,
-        EntityType.ProjectileExpl,
+        EntityType.GasolineStain,
         p => p.name.Length == obj?.name.Length - 7 && (obj?.name.Contains(p.name) ?? false)
     );
 


### PR DESCRIPTION
Oil is completely unsynced right now, if you spray gasoline nobody else sees the spray, the stains or the oil on enemies, and you can't light a friend's oil. This makes all of it work, you can see each other spray, draw on the floor together and light each other's drawings, late joiners get the stains too.

1. Droplets are one-shot spawn events like hitscans. They just fly in an arc so syncing 50 projectiles a second as entities like nails is ultrakill, the sprayer sends p+velocity and everyone else spawns fake copies and lets local physics fly them. The client copies have their trigger blocked so they can't make phantom stains or oil anything, hits only count on the sprayer's machine.
2. New `Stain` entity made from a `GasolineStain.AttachTo` postfix. Remotes spawn it, raycast for the surface and call `AttachTo` themselves so it registers with `StainVoxelManager` and can actually catch fire for them too. I tried putting stains on the droplet's death packet first but death packets for unknown entities get dropped, a droplet sprayed at your feet dies before anyone even knows it exists so most stains just vanished. Entities also give late joiners every stain when they join.
3. Oiled up enemies go through the death packet flags, an `AddFlammable` postfix broadcasts the fuel and everyone applies the same amount, so the oil shader and burning just work everywhere. Same idea as how damage is synced.
4. New `PacketType.Ignition`, when `TryIgniteAt` actually lights something the position gets broadcast and everyone replays it. Already burning voxels return false so it can't spam. Fire spread after that just runs locally on everyone's machine, stays consistent because the stains are synced.

Stains get their own 256 slot pool, otherwise they'd be in the 24 slot projectile pool and your drawing would start eating itself after 24 stains. Players can really make a metric fuckton of stains so I'll leave it up to adi how many to allow, 256 was kinda random tbhhhhh

Stains never move so I added an `Entity.Dormant` thingy the snapshot pools check next to `Hidden`, a stain stops sending after like 16 snapshots (like 2 seconds, might need more?) and wakes up when someone joins or ownership transfers. Without it a big drawing re-sends identical snapshots forever for no reason. It's not `Hidden` on purpose so `Optimize` doesn't eat them and death packets still find them. If snapshots ever go unreliable these would need acks, heads up.

`GasolineStain` has no destroy method to patch like `Nail.OnDestroy` so a little `Sentinel` component kills the entity in `OnDestroy` when it burns away or a checkpoint restart eats it.

Stuff I didn't fix/can't fix/doesn't really matter: late joiners don't see oil that was put on enemies before they joined ig, and restarting your checkpoint clears your local copies of other people's stains (the voxel proxies have `DestroyOnCheckpointRestart`, vanilla thing). Also if you have unlimited ammo cheat on the oil stains and fire effects don't disappear. First one is whatever, the other two would be kinda easyish to fix but not super worth it the effort and should prolly be in separate PRs. 