### PR TITLE
Add client-side parry impact pause

### DIFF
--- a/src/Jaket/Harmony/ArmsPatch.cs
+++ b/src/Jaket/Harmony/ArmsPatch.cs
@@ -1,5 +1,6 @@
 namespace Jaket.Harmony;
 
+using System.Collections;
 using UnityEngine;
 
 using Jaket.Content;
@@ -8,7 +9,12 @@ using Jaket.Net.Types;
 
 public static class ArmsPatch
 {
+    const float PARRY_PAUSE = .25f;
+
     static EnemyIdentifier caught;
+    static Animator pausedAnimator;
+    static Coroutine resumeCoroutine;
+    static float previousAnimatorSpeed;
 
     [DynamicPatch(typeof(HookArm), nameof(HookArm.FixedUpdate))]
     [Postfix]
@@ -40,4 +46,36 @@ public static class ArmsPatch
     [DynamicPatch(typeof(Punch), nameof(global::Punch.GetParryLookTarget))]
     [Postfix]
     static void Parry() => parried = true;
+
+    [DynamicPatch(typeof(Punch), nameof(global::Punch.Parry))]
+    [Postfix]
+    static void PausePunch(global::Punch __instance)
+    {
+        var animator = __instance.anim;
+        if (!animator) return;
+
+        if (resumeCoroutine != null) Plugin.Instance.StopCoroutine(resumeCoroutine);
+        if (pausedAnimator != animator)
+        {
+            ResumePunch();
+            pausedAnimator = animator;
+            previousAnimatorSpeed = animator.speed;
+        }
+
+        animator.speed = 0f;
+        resumeCoroutine = Plugin.Instance.StartCoroutine(ResumePunchLater());
+    }
+
+    static IEnumerator ResumePunchLater()
+    {
+        yield return new WaitForSecondsRealtime(PARRY_PAUSE);
+        ResumePunch();
+    }
+
+    static void ResumePunch()
+    {
+        if (pausedAnimator) pausedAnimator.speed = previousAnimatorSpeed;
+        pausedAnimator = null;
+        resumeCoroutine = null;
+    }
 }


### PR DESCRIPTION
adds a small hitpause on the arm animator which makes parries feel better online. Also works if someone parries during the pause/animation isn't done. It's set to 0.25f right now which matches the default game parry. 0.15f also works fine too but feels a little light. Video below features 0.15f. 


https://github.com/user-attachments/assets/617e578f-6688-4301-abd2-0a9bc5f9f175

